### PR TITLE
Bump Kotlin and Kotlin Native

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.60'
 
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-konan.plugin.version=0.7.1
+konan.plugin.version=0.8.2

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.61'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
This PR is responsible for bumping the versions of Kotlin (1.2.60) and Kotlin Native (0.8.2).